### PR TITLE
Use eglGetPlatformDisplayEXT and just use the DRI device directly

### DIFF
--- a/kmscube.c
+++ b/kmscube.c
@@ -121,34 +121,12 @@ static uint32_t find_crtc_for_connector(const drmModeRes *resources,
 
 static int init_drm(void)
 {
-	static const char *modules[] = {
-		"rockchip",
-		"exynos",
-		"i915",
-		"msm",
-		"nouveau",
-		"omapdrm",
-		"radeon",
-		"tegra",
-		"vc4",
-		"virtio_gpu",
-		"vmwgfx",
-	};
 	drmModeRes *resources;
 	drmModeConnector *connector = NULL;
 	drmModeEncoder *encoder = NULL;
 	int i, area;
 
-	for (i = 0; i < ARRAY_SIZE(modules); i++) {
-		printf("trying to load module %s...", modules[i]);
-		drm.fd = drmOpen(modules[i], NULL);
-		if (drm.fd < 0) {
-			printf("failed.\n");
-		} else {
-			printf("success.\n");
-			break;
-		}
-	}
+	drm.fd = open("/dev/dri/card0", O_RDWR);
 
 	if (drm.fd < 0) {
 		printf("could not open drm device\n");

--- a/kmscube.c
+++ b/kmscube.c
@@ -42,6 +42,8 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#include <assert.h>
+
 #include "esUtil.h"
 
 
@@ -120,6 +122,7 @@ static uint32_t find_crtc_for_connector(const drmModeRes *resources,
 static int init_drm(void)
 {
 	static const char *modules[] = {
+		"rockchip",
 		"exynos",
 		"i915",
 		"msm",
@@ -393,7 +396,12 @@ static int init_gl(void)
 			"    gl_FragColor = vVaryingColor;  \n"
 			"}                                  \n";
 
-	gl.display = eglGetDisplay(gbm.dev);
+	PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display = NULL;
+	get_platform_display =
+		(void *) eglGetProcAddress("eglGetPlatformDisplayEXT");
+	assert(get_platform_display != NULL);
+
+	gl.display = get_platform_display(EGL_PLATFORM_GBM_KHR, gbm.dev, NULL);
 
 	if (!eglInitialize(gl.display, &major, &minor)) {
 		printf("failed to initialize\n");


### PR DESCRIPTION
These two patches allow me to run **kmscube** on a RK3288 ARMv7 board, using Mali Midgard Wayland/DRM r12p0 drivers.

The most essential patch is the one using `eglGetPlatformDisplayEXT` instead of `eglGetDisplay`. With only `eglGetDisplay`, the program does not run with Mali drivers. It's possible to rework the patch in order to try using `eglGetPlatformDisplayEXT` and use `eglGetDisplay` if things go wrong.

The second patch gets rid of checking every potential past, present and future DRM module and just use the Direct Rendering Interface directly. If `/dev/dri/card0` is not available, the current Linux installation is either very esoteric (e.g. uses `udev` to rename the device name) or does not have a working DRM driver.
It might be possible to use sysfs to get the right DRI node everytime.

Still, `/dev/dri/card0` works for most installations and is more resilient than module checking.