### PR TITLE
Allow the use of CMake to compile the example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(KMSCube)
+
+include(FindPkgConfig)
+
+pkg_search_module(DRM REQUIRED libdrm)
+include_directories(${DRM_INCLUDE_DIRS})
+add_executable(kmscube kmscube.c esTransform.c)
+target_link_libraries(kmscube ${DRM_LIBRARIES} GLESv2 EGL gbm m)


### PR DESCRIPTION
This adds the possibility to use CMake, instead of the Autotools, to
build the example. Autogen is still present and usable, though.

The biggest problem I have with ./autogen.sh is that it takes
between 30 seconds to one minute to get the whole project prepared, on
some ARMv7 boards. CMake takes a few seconds at most, on the same
hardware.

Signed-off-by: Myy <myy@miouyouyou.fr>