### PR TITLE
Add README to point at gitlab

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+Please note that kmscube move to https://gitlab.freedesktop.org/mesa/kmscube

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-Please note that kmscube move to https://gitlab.freedesktop.org/mesa/kmscube

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Please note that kmscube move to [https://gitlab.freedesktop.org/mesa/kmscube]


### PR DESCRIPTION
Probably should add a proper README on the gitlab.fd.o repo, but I'm too lazy.